### PR TITLE
Adding pyproject.toml with updated requirement for scikit-learn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ requires-python = '>= 3.0'
 dependencies = [
     'scikit-learn',
     'scipy',
-    'pandas,
+    'pandas',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+# Project information: PyPI and Pip
+
+[project]
+name = 'chowtest'
+license = {file = "LICENSE"}
+authors = [{name='David Woroniuk'}]
+keywords = []
+classifiers = []
+readme = 'Readme.md'
+version = '0.0.1'
+requires-python = '>= 3.0'
+dependencies = [
+    'scikit-learn',
+    'scipy',
+    'pandas,
+]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+from unittest import TestCase
+
+from pandas import DataFrame
+from chow_test import chow_test
+
+class TestBase(TestCase):
+    def test_base(self):
+
+        data = [[11, 10, 9], [11,  15, 9], [12, 14, 16], [11, 10, 9], [11,  15, 9],
+                [12, 14, 16], [11, 10, 9], [11,  15, 9], [12, 14, 16], [11, 10, 9],
+                [11,  15, 9], [12, 14, 16], [11, 10, 9], [11,  15, 9], [12, 14, 16]]
+        new_data = DataFrame(data, columns=["A", "B", "C"])
+        chow, p_val = chow_test(new_data["B"], new_data["A"], 8, 9, 0.01)
+
+        self.assertEqual(chow,0.7978723404255487)
+        self.assertEqual(p_val, 0.4769872586883571)


### PR DESCRIPTION
Since the current PyPi package can no more be installed due to sklear being replaced by scikit-learn -> this should at least allow to install the package directly from the repo. If I can help updating the PyPi package - let me know.